### PR TITLE
partly solve recv data interrupt on http_parse

### DIFF
--- a/cgiserver/http_parser.py
+++ b/cgiserver/http_parser.py
@@ -105,10 +105,10 @@ class HttpRequestParser:
         """Parse the headers of the http request"""
         def headerline_interrupt_patch(queue: SplitQueue):
             """
-            
+
             AsWeKnow header_line is \r\n(end flag) | ..*\r\n..*(header_content)
 
-            assert queue & next_queue is header_line 
+            assert queue & next_queue is header_line
             // TODO: bound condition would cause error
             discuss:
             have known queue, don't know next_queue.
@@ -128,17 +128,18 @@ class HttpRequestParser:
                     assert line is header_content.
 
             """
-            
+
             line = queue.pop("\r\n")
-            if line is None: return line
+            if line is None:
+                return line
 
             if queue.empty and len(line) > 0:
                 queue.append(line)
                 return None
 
             return line
-        
-        
+
+
         while not self.queue.empty:
             headerline = headerline_interrupt_patch(self.queue)
             if headerline is None:

--- a/cgiserver/http_parser.py
+++ b/cgiserver/http_parser.py
@@ -1,5 +1,4 @@
 """HTTP Parser"""
-from email import header
 import json
 import urllib.parse as urlparse
 from typing import Optional, Union

--- a/cgiserver/http_parser.py
+++ b/cgiserver/http_parser.py
@@ -103,45 +103,9 @@ class HttpRequestParser:
 
     def _parse_headers(self) -> None:
         """Parse the headers of the http request"""
-        def headerline_interrupt_patch(queue: SplitQueue):
-            """
-
-            AsWeKnow header_line is \r\n(end flag) | ..*\r\n..*(header_content)
-
-            assert queue & next_queue is header_line
-            // TODO: bound condition would cause error
-            discuss:
-            have known queue, don't know next_queue.
-            if queue.empty == false:
-                assert queue is \r\n | ..*[!\r\n] | ..*\r\n.*
-                exec line = queue.pop(delimiter=\r\n)
-                if queue.empty:
-                    assert queue is \r\n | ..*[!\r\n]
-                    assert line is EMPTY | ..*
-                    if line.empty:
-                        assert line is end_flag.
-                    else:
-                        push ..*
-                else: // queue not empty
-                    assert queue is ..*\r\n.*
-                    assert line is ..*
-                    assert line is header_content.
-
-            """
-
-            line = queue.pop("\r\n")
-            if line is None:
-                return line
-
-            if queue.empty and len(line) > 0:
-                queue.append(line)
-                return None
-
-            return line
-
 
         while not self.queue.empty:
-            headerline = headerline_interrupt_patch(self.queue)
+            headerline = self.queue.pop_str_end_with("\r\n")
             if headerline is None:
                 break
 

--- a/cgiserver/utils/queue.py
+++ b/cgiserver/utils/queue.py
@@ -54,3 +54,24 @@ class SplitQueue:
         first, *rest = self._data.split(delimiter, 1)
         self._data = "" if not rest else rest[0]
         return first
+
+    def pop_str_end_with(self, delimiter: Union[str, bytes]) -> Union[str, bytes]:
+        """Pop the first element before the delimiter.
+
+        Args:
+            delimiter (Union[str, bytes]): delimiter to split the string.
+
+        Raises:
+            ValueError: pop if the queue is already empty.
+
+        Returns:
+            Union[str, bytes]: the first element end with the delimiter.
+        """
+        if self.empty:
+            raise ValueError("SplitQueue is empty")
+        first, *rest = self._data.split(delimiter, 1)
+        if len(rest) == 0:
+            return None
+
+        self._data = "" if not rest else rest[0]
+        return first


### PR DESCRIPTION
            AsWeKnow header_line is \r\n(end flag) | ..*\r\n..*(header_content)

            assert queue & next_queue is header_line 
            // TODO: bound condition would cause error
            discuss:
            have known queue, don't know next_queue.
            if queue.empty == false:
                assert queue is \r\n | ..*[!\r\n] | ..*\r\n.*
                exec line = queue.pop(delimiter=\r\n)
                if queue.empty:
                    assert queue is \r\n | ..*[!\r\n]
                    assert line is EMPTY | ..*
                    if line.empty:
                        assert line is end_flag.
                    else:
                        push ..*
                else: // queue not empty
                    assert queue is ..*\r\n.*
                    assert line is ..*
                    assert line is header_content.

            